### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # JavaScript-DecimalIntegersInWords
 
-This adapter when it is passed a positive whole number will return that number in words with the appropriate punctuation marks.
+This adapter when it is passed a positive whole number will return that number in words with the appropriate punctuation marks.  If the positive whole number passed is in exponential notation, that is the parameter passed to the adapter is expressed in exponential notation, then this is considered to be an exception by the adapter.


### PR DESCRIPTION
Added extra sentence in the description of the adapter in README.md which explains that whole numbers in exponential notation format are considered to be an exception.